### PR TITLE
adding check for jq and other tweaks

### DIFF
--- a/singularity2docker.sh
+++ b/singularity2docker.sh
@@ -75,29 +75,28 @@ echo "1. Checking for software dependencies, Singularity and Docker..."
 
 # The image must exist
 
+
 if [ ! -e "${image}" ]; then
     echo "Cannot find ${image}, did you give the correct path?"
     exit 1
 fi
 
 
-# Singularity must be installed
+function is_installed () {
+    software=${1}
+    if hash ${software} 2>/dev/null; then
+        echo "Found ${software} $(${software} --version)"
+    else
+        echo "${software} must be installed to use singularity2docker.sh"
+        exit 1
+    fi
+}
 
-if hash singularity 2>/dev/null; then
-   echo "Found Singularity $(singularity --version)"
-else
-   echo "Singularity must be installed to use singularity2docker.sh"
-   exit 1
-fi
 
-# Docker must be installed
-
-if hash docker 2>/dev/null; then
-   echo "Found Docker $(docker --version)"
-else
-   echo "Docker must be installed to use singularity2docker.sh"
-   exit 1
-fi
+# Singularity, Docker, and jq must be installed
+is_installed singularity
+is_installed docker
+is_installed jq
 
 
 ################################################################################
@@ -161,7 +160,7 @@ done
 echo "Adding command..."
 echo '#!/bin/sh
 . /environment
-exec /.singularity.d/runscript' > ${sandbox}/run_singularity2docker.sh
+exec /.singularity.d/runscript "$@"' > ${sandbox}/run_singularity2docker.sh
 echo "CMD [\"/bin/bash\", \"run_singularity2docker.sh\"]" >> $sandbox/Dockerfile
 
 ################################################################################


### PR DESCRIPTION
This pull request will do the following:

 - adding a check for jq to close #1 (thanks tru!) 
 - turning the check for software to be installed into a function (since we do it three times).
 - adding args to be passed to the runscript e.g.,

```
root@9cb13b4dbebf:/# cat /run_singularity2docker.sh 
#!/bin/sh
. /environment
exec /.singularity.d/runscript "$@"
```
I think this would likely come up as an issue at some point, Docker will pass in arguments when you exec, but passing on from this script wouldn't just happen by magic :)

@truatpasteurdotfr would you care to look this over if everything looks ok?