### PR TITLE
Remove pipe to /dev/null for better debugging, fix parsing with jq

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ This is a simple script to convert a Singularity image back to Docker, preservin
 environment, labels, and runscript. The usage is as follows:
 
 ```bash
-./singularity2docker.sh -n newcontainer:tag singularity-container.simg
+./singularity2docker.sh -n newcontainer:tag singularity-container.sif
 ```
 
 The above says "Create a new container called newcontainer:tag (-n == name) from
-the Singularity container singularity-container.simg
+the Singularity container singularity-container.sif
 
 ## Example
 
@@ -153,7 +153,7 @@ $ docker inspect newcontainer:tag
 ```
 $ docker run newcontainer:tag
 RaawwWWWWWRRRR!!
-$ singularity run singularity-container.simg 
+$ singularity run singularity-container.sif
 RaawwWWWWWRRRR!!
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,15 @@ environment, labels, and runscript. The usage is as follows:
 ```
 
 The above says "Create a new container called newcontainer:tag (-n == name) from
-the Singularity container singularity-container.sif
+the Singularity container singularity-container.sif The other argument you can provide
+to skip cleanup of the sandbox (if you intend to build again) is `--no-cleanup`.
 
 ## Example
 
 ```
-$ ./singularity2docker.sh -n newcontainer:tag singularity-container.simg
+$ ./singularity2docker.sh -n newcontainer:tag singularity-container.sif
 
-Input Image: singularity-container.simg
+Input Image: singularity-container.sif
 
 1. Checking for software dependencies, Singularity and Docker...
 Found Singularity 2.4.5-master.g0b17e18

--- a/singularity2docker.sh
+++ b/singularity2docker.sh
@@ -31,12 +31,14 @@ if [ $# == 0 ] ; then
     echo "OPTIONS:
 
           -n|--name: docker container name (container:new)
+          --no-cleanup: don't remove build sandbox and Dockerfile within
 
           "
     exit 1;
 fi
 
 container="container:new"
+cleanup="true"
 
 while true; do
     case ${1:-} in
@@ -47,6 +49,10 @@ while true; do
         --name|-n|n)
             shift
             container="${1:-}";
+            shift
+        ;;
+        --no-cleanup)
+            cleanup="false";
             shift
         ;;
         -*)
@@ -63,6 +69,7 @@ image=$1
 
 echo ""
 echo "Input Image: ${image}"
+echo "Cleanup: ${cleanup}"
 
 
 
@@ -175,4 +182,10 @@ echo "4.  Build away, Merrill!"
 docker build -t ${container} ${sandbox}
 echo "Created container ${container}"
 echo "docker inspect ${container}"
-rm -rf ${sandbox}
+
+if [ "$cleanup" == "true" ]; then
+    echo "Cleaning up $sandbox"
+    rm -rf ${sandbox}
+else
+    echo "Sandbox is at $sandbox"
+fi


### PR DESCRIPTION
This will remove pipes to /dev/null so the script doesn't exit silently without telling the user of an error, along with fixing the jq parsing of metadata. Singularity hasn't been consistent with how the metadata is produced and organized, but the most we can do is update to the current version and provide a note, assuming others do that too. This will close #4 and close #5.